### PR TITLE
Upgrade target framework from net5.0-windows to net10.0-windows

### DIFF
--- a/1pdf.sln
+++ b/1pdf.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32802.440
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "1pdf", "1pdf\1pdf.csproj", "{08BC3B78-25A6-45A1-A63D-BFBEE9D4021A}"
 EndProject

--- a/1pdf/1pdf.csproj
+++ b/1pdf/1pdf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <RootNamespace>_1pdf</RootNamespace>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>


### PR DESCRIPTION
.NET 5 reached end-of-life in May 2022 and has unfixed CVEs. This upgrades the project to .NET 10 LTS (supported until May 2028). Build verified: 0 errors, only expected NU1701 compatibility warning for PdfiumViewer (works at runtime). Also updates the solution file to Visual Studio 2022 toolset version.